### PR TITLE
Fix cmake error.

### DIFF
--- a/scripts/libarduino_uno.cmake
+++ b/scripts/libarduino_uno.cmake
@@ -62,7 +62,7 @@ if (NOT PORT)
     set(PORT ${ARDUINO_UNO_PORT})
 endif()
 
-add_custom_target(reset_uno)
+add_custom_target(reset)
 add_custom_command(TARGET reset POST_BUILD
     COMMAND echo 0 > ${PORT}
 )


### PR DESCRIPTION
The add_custom_command referred to a reset target while the target was defined as reset_uno.